### PR TITLE
Patch config dir.

### DIFF
--- a/ports/gmloader/libyoyo.c
+++ b/ports/gmloader/libyoyo.c
@@ -88,7 +88,7 @@ void setup_platform_savedir(const char *gamename)
     //TODO:: Update psvita sdk and use the newlib mkdir.
 #ifndef PLATFORM_VITA
     // For linux targets
-	snprintf(platform_savedir, sizeof(platform_savedir), "%s/.config/%s/", getenv("HOME"), gamename);
+	snprintf(platform_savedir, sizeof(platform_savedir), "%s/.config/gmloader/%s/", getenv("HOME"), gamename);
 	warning("Saving to folder %s.\n", platform_savedir);
 
     char mkdir_cmd[PATH_MAX];


### PR DESCRIPTION
Each game/apk has its config saved to individual folders as in `~/.config/<apk>`. We (well, I and the one other I discussed it with) think it would be cleaner if they were saved under a main `gmloader` dir as in `~/.config/gmloader/<apk>` instead.

If it works like I think it does, this patch does exactly that. (It seems to, anyway, but I have zero knowledge what I'm  doing and so I can only hope this doesn't break something, somewhere else. But it *does* save config to the new directory, and even loads my old savegame if I move the file over so it shows promise, I think.)